### PR TITLE
Modify Node Image PATH variable.

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -15,5 +15,8 @@ if [ "$USER_NAME" == "" ]; then
   usermod -u $USER_ID $USER_NAME
 fi
 
+# Make sure node modules is part of the path.
+export PATH="$PATH:./node_modules/.bin"
+
 # Execute the command
 gosu ${USER_NAME} "$@"

--- a/slim/entrypoint.sh
+++ b/slim/entrypoint.sh
@@ -26,5 +26,8 @@ if [ "$USER_NAME" == "" ]; then
   chown ${USER_NAME} $HOME
 fi
 
+# Make sure node modules is part of the path.
+export PATH="$PATH:./node_modules/.bin"
+
 # Execute the command
 gosu ${USER_NAME} "$@"


### PR DESCRIPTION
### Issue:
Node modules is a very common use case for node. My suggestion is to add it on the path for the image and add it at the end so it doesn't interfere with any other paths executables.

### Solution:
Add node modules at the end of the path for both alpine and slim.